### PR TITLE
added migrations to create tables

### DIFF
--- a/src/database/BaseDatabase.ts
+++ b/src/database/BaseDatabase.ts
@@ -9,7 +9,7 @@ export abstract class BaseDatabase{
            port: 3306,
            user: process.env.DB_USER,
            password: process.env.DB_PASSWORD,
-           database: process.env.DB_DATABASE,
+           database: process.env.DB_SCHEMA,
            multipleStatements: true
         },
      });

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -1,0 +1,18 @@
+import knex from "knex"
+import dotenv from "dotenv"
+
+dotenv.config()
+
+const connection = knex({
+   client: "mysql",
+   connection: {
+      host: process.env.DB_HOST,
+      port: 3306,
+      user: process.env.DB_USER,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_SCHEMA,
+      multipleStatements: true
+   },
+});
+
+export default connection


### PR DESCRIPTION
Adicionado migration para criação de tabelas no db

obs1: .env não está no .gitignore para facilitar na hora de preenchimento, porém deverá ser adicionado antes de envio para o repositório;

obs2: colocar o connection no .gitignore pois fiz ele apenas para o migration.